### PR TITLE
Make callback optional

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -100,7 +100,7 @@ var teenyconf = function(configPath) {
         try {
             fs.writeFile(_metas.configPath, output, function(err) {
                 if(err) throw err;
-                else callback();
+                if (callback) callback();
             });
         }
         catch(err) {


### PR DESCRIPTION
Callbacks to save should be optional. Check to make sure callback has been supplied before calling it.